### PR TITLE
fix: pino options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,13 +12,13 @@ import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
 import { err, req, res, SerializedError, SerializedRequest, SerializedResponse } from 'pino-std-serializers';
 
-declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(opts?: Options<IM, SR>, stream?: pino.DestinationStream): HttpLogger<IM, SR>;
+declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>>(opts?: Opts, stream?: pino.DestinationStream): HttpLogger<IM, SR, Opts>;
 
 declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pino.DestinationStream): HttpLogger<IM, SR>;
 
-export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse> {
+export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>> {
     (req: IM, res: SR, next?: () => void): void;
-    logger: pino.Logger;
+    logger: pino.Logger<Opts>;
 }
 export type ReqId = number | string | object;
 


### PR DESCRIPTION
**Issue**
```
import { pinoHttp } from 'pino-http';

const httpLogger = pinoHttp({
    customLevels: {
        log: 20,
    },
});

const logger = httpLogger.logger;

function f(level: 'warn' | 'info' | 'log', message: string): void {
  logger[level](message);
}

```
This code is correct but currently throws a `ts(7053) : Element implicitly has an 'any' type` because TS can't see the custom level added in the configuration.